### PR TITLE
[patch] handle second benign exception(#AC exception)

### DIFF
--- a/arch/x86/kvm/vmx/vmx.c
+++ b/arch/x86/kvm/vmx/vmx.c
@@ -4773,11 +4773,13 @@ static int handle_exception_nmi(struct kvm_vcpu *vcpu)
 	}
 
 	/*
-	 * The #PF with PFEC.RSVD = 1 indicates the guest is accessing
+	 * 1. The #PF with PFEC.RSVD = 1 indicates the guest is accessing
 	 * MMIO, it is better to report an internal error.
 	 * See the comments in vmx_handle_exit.
+	 * 2. Second exception is benign exception, replace prior exception, only #AC
 	 */
 	if ((vect_info & VECTORING_INFO_VALID_MASK) &&
+	    !is_exception_n(intr_info, AC_VECTOR) &&
 	    !(is_page_fault(intr_info) && !(error_code & PFERR_RSVD_MASK))) {
 		vcpu->run->exit_reason = KVM_EXIT_INTERNAL_ERROR;
 		vcpu->run->internal.suberror = KVM_INTERNAL_ERROR_SIMUL_EX;


### PR DESCRIPTION
Under non privileged level, benign exception while handling a prior exception.

In my test, first exception is soft interrupt and second is #AC,
KVM will report internal error.
The detailed report is as follows：

KVM internal error. Suberror: 2
extra data[0]: 800004e0
extra data[1]: 80000b11
extra data[2]: 0
EAX=01058f15 EBX=01000ae6 ECX=01007f90 EDX=01058f20
ESI=01000ab2 EDI=0104c287 EBP=01007f98 ESP=01058f15
EIP=01000aed EFL=00050002 [-------] CPL=3 II=0 A20=1 SMM=0 HLT=0
ES =0043 00000000 ffffffff 00c0f300 DPL=3 DS [-WA]
CS =003b 00000000 ffffffff 00c0fb00 DPL=3 CS32 [-RA]
SS =0043 00000000 ffffffff 00c0f300 DPL=3 DS [-WA]
DS =0043 00000000 ffffffff 00c0f300 DPL=3 DS [-WA]
FS =0043 00000000 ffffffff 00c0f300 DPL=3 DS [-WA]
GS =0043 00000000 ffffffff 00c0f300 DPL=3 DS [-WA]
LDT=0000 00000000 0000ffff 00008200 DPL=0 LDT
TR =0080 01049280 0000ffff 00008b00 DPL=0 TSS32-busy
GDT= 01049000 0000027f
IDT= 0104ac80 00000fff
CR0=80050021 CR2=bffff008 CR3=0105c000 CR4=00002010
DR0=0000000000000000 DR1=0000000000000000 DR2=0000000000000000 DR3=0000000000000000
DR6=00000000ffff0ff0 DR7=0000000000000400
EFER=0000000000000000
